### PR TITLE
Changed structure of Introduction

### DIFF
--- a/content/docs/introduction/features/collections-filter.md
+++ b/content/docs/introduction/features/collections-filter.md
@@ -1,0 +1,6 @@
+---
+title: "Filtering"
+weight: 8
+---
+
+Fill

--- a/content/docs/introduction/features/collections-pagination.md
+++ b/content/docs/introduction/features/collections-pagination.md
@@ -1,0 +1,6 @@
+---
+title: "Pagination"
+weight: 8
+---
+
+Fill

--- a/content/docs/introduction/features/index.md
+++ b/content/docs/introduction/features/index.md
@@ -1,0 +1,8 @@
+---
+layout: "redirect"
+---
+title: "Features"
+weight: 8
+---
+
+Fill

--- a/content/docs/introduction/features/index.md
+++ b/content/docs/introduction/features/index.md
@@ -1,8 +1,6 @@
 ---
-layout: "redirect"
----
 title: "Features"
-weight: 8
+weight: 5
 ---
 
 Fill

--- a/content/docs/introduction/features/resource-embedding.md
+++ b/content/docs/introduction/features/resource-embedding.md
@@ -1,0 +1,6 @@
+---
+title: "Resource Embedding"
+weight: 8
+---
+
+Fill

--- a/content/docs/introduction/features/sparse-fieldsets.md
+++ b/content/docs/introduction/features/sparse-fieldsets.md
@@ -1,0 +1,6 @@
+---
+title: "Sparse Fieldsets"
+weight: 8
+---
+
+Fill

--- a/content/docs/introduction/key-concepts/hypermedia.md
+++ b/content/docs/introduction/key-concepts/hypermedia.md
@@ -1,6 +1,6 @@
 ---
 title: "Hypermedia"
-weight: 6
+weight: 200
 ---
 
 Fill

--- a/content/docs/introduction/key-concepts/shared-vocabularies.md
+++ b/content/docs/introduction/key-concepts/shared-vocabularies.md
@@ -1,6 +1,6 @@
 ---
 title: "Shared vocabularies"
-weight: 6
+weight: 100
 ---
 
 Fill


### PR DESCRIPTION
I've created a "Features" section to add the explanation of the different features that APIO adds to the APIs and reorganized the "Key Concepts" section to contain both Hypermedia and "Shared vocabularies" as the first two Key concepts (I had to move Hypermedia" from outside key concepts) and then the rest of key concepts.